### PR TITLE
Google OAuth2 로그인 api 성공 케이스 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,4 +178,4 @@ gradle-app.setting
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,gradle,java,macos
 
 # Ignore secrets file
-secrets.properties
+secrets*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/intellij+all,gradle,java,macos
+
+# Ignore secrets file
+secrets.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     runtimeOnly 'com.h2database:h2'
 
@@ -31,6 +32,24 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 
+    // for WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     // for apache commons
     implementation 'org.apache.commons:commons-lang3'
+
+    // netty_resolver_dns_native for M1
+    implementation("io.netty:netty-resolver-dns-native-macos:4.1.75.Final") {
+        artifact {
+            classifier = "osx-aarch_64"
+        }
+    }
+
+    // jjwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
+            // Uncomment the next line if you want to use RSASSA-PSS (PS256, PS384, PS512) algorithms:
+            //'org.bouncycastle:bcprov-jdk15on:1.70',
+            'io.jsonwebtoken:jjwt-jackson:0.11.5' // or 'io.jsonwebtoken:jjwt-gson:0.11.5' for gson
+
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     runtimeOnly 'com.h2database:h2'
+
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
+    // for apache commons
+    implementation 'org.apache.commons:commons-lang3'
 }

--- a/app/src/main/java/org/project/TicketBookingApplication.java
+++ b/app/src/main/java/org/project/TicketBookingApplication.java
@@ -1,4 +1,4 @@
-package org.project.ticketbooking;
+package org.project;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/app/src/main/java/org/project/domain/member/controller/OAuthController.java
+++ b/app/src/main/java/org/project/domain/member/controller/OAuthController.java
@@ -4,8 +4,8 @@ import org.project.domain.member.dto.AuthTokens;
 import org.project.domain.member.service.OAuthService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,11 +14,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/oauth")
 public class OAuthController {
 
-  @Value("${oauth2.google.client-id}")
-  private String googleClientId;
-  @Value("${oauth2.google.client-secret}")
-  private String googleClientSecret;
-
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final OAuthService oAuthService;
 
@@ -26,8 +21,11 @@ public class OAuthController {
     this.oAuthService = oAuthService;
   }
 
-  @RequestMapping("/google")
-  public ResponseEntity<AuthTokens> loginWithGoogle(@RequestParam String code) {
+  @GetMapping("/google")
+  public ResponseEntity<AuthTokens> loginWithGoogle(@RequestParam(required = false) String code,
+      @RequestParam(required = false) String error) {
+
     return ResponseEntity.ok(oAuthService.loginWithGoogle(code));
   }
+
 }

--- a/app/src/main/java/org/project/domain/member/controller/OAuthController.java
+++ b/app/src/main/java/org/project/domain/member/controller/OAuthController.java
@@ -1,0 +1,33 @@
+package org.project.domain.member.controller;
+
+import org.project.domain.member.dto.AuthTokens;
+import org.project.domain.member.service.OAuthService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/oauth")
+public class OAuthController {
+
+  @Value("${oauth2.google.client-id}")
+  private String googleClientId;
+  @Value("${oauth2.google.client-secret}")
+  private String googleClientSecret;
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final OAuthService oAuthService;
+
+  public OAuthController(OAuthService oAuthService) {
+    this.oAuthService = oAuthService;
+  }
+
+  @RequestMapping("/google")
+  public ResponseEntity<AuthTokens> loginWithGoogle(@RequestParam String code) {
+    return ResponseEntity.ok(oAuthService.loginWithGoogle(code));
+  }
+}

--- a/app/src/main/java/org/project/domain/member/domain/Member.java
+++ b/app/src/main/java/org/project/domain/member/domain/Member.java
@@ -1,0 +1,36 @@
+package org.project.domain.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+@ToString
+public class Member {
+
+  private Long id;
+  @NonNull
+  final private String email;
+  @NonNull
+  final private String provider;
+
+
+  @Override
+  public boolean equals(Object o) {
+    return EqualsBuilder.reflectionEquals(this, o);
+  }
+
+  @Override
+  public int hashCode() {
+    return HashCodeBuilder.reflectionHashCode(this);
+  }
+
+}

--- a/app/src/main/java/org/project/domain/member/dto/AuthTokens.java
+++ b/app/src/main/java/org/project/domain/member/dto/AuthTokens.java
@@ -1,0 +1,15 @@
+package org.project.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AuthTokens {
+
+  private final String access;
+  private final String refresh;
+
+  public AuthTokens(String accessToken, String refreshToken) {
+    this.access = accessToken;
+    this.refresh = refreshToken;
+  }
+}

--- a/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenRequest.java
+++ b/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenRequest.java
@@ -1,0 +1,28 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+
+/**
+ * Authorization server에 access 토큰 요청 포맷. RFC 6749 내용 준수. (<a
+ * href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.2">링크</a>)
+ */
+@Getter
+@ToString
+@AllArgsConstructor
+public class OAuthAccessTokenRequest {
+
+  private String code;
+  @JsonProperty("client_id")
+  private String clientId;
+  @JsonProperty("client_secret")
+  private String clientSecret;
+  @JsonProperty("redirect_uri")
+  private String redirectUri;
+  @JsonProperty("grant_type")
+  private String grantType;
+
+}

--- a/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
@@ -1,0 +1,27 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * Authorization server에 access 토큰 요청시 응답 포맷. RFC 6749 내용 준수. (<a
+ * href="https://datatracker.ietf.org/doc/html/rfc6749#section-5.1">링크</a>)
+ */
+@ToString
+@Getter
+@NoArgsConstructor
+public class OAuthAccessTokenResponse {
+
+  @JsonProperty("access_token")
+  private String accessToken;
+  @JsonProperty("token_type")
+  private String tokenType;
+  @JsonProperty("expires_in")
+  private String expiresIn;
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+  private String scope;
+
+}

--- a/app/src/main/java/org/project/domain/member/dto/UserInfoResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/UserInfoResponse.java
@@ -1,0 +1,73 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Shcema reference from <a
+ * href="googleapis.com/discovery/v1/apis/oauth2/v2/rest">googleapis.com/discovery/v1/apis/oauth2/v2/rest</a>
+ */
+@Getter
+@ToString
+public class UserInfoResponse {
+
+  /**
+   * The user's email address.
+   */
+  private String email;
+
+  /**
+   * The user's last name.맷
+   */
+  @JsonProperty("family_name")
+  private String familyName;
+
+  /**
+   * The user's gender.
+   */
+  private String gender;
+
+  /**
+   * The user's first name.
+   */
+  @JsonProperty("given_name")
+  private String givenName;
+
+  /**
+   * The hosted domain e.g. example.com if the user is Google apps user.
+   */
+  private String hd;
+
+  /**
+   * The obfuscated ID of the user.
+   */
+  private String id;
+
+  /**
+   * URL of the profile page.
+   */
+  private String link;
+
+  /**
+   * The user's preferred locale.
+   */
+  private String locale;
+
+  /**
+   * The user's full name.
+   */
+  private String name;
+
+  /**
+   * URL of the user's picture image.
+   */
+  private String picture;
+
+  /**
+   * Boolean flag which is true if the email address is verified. Always verified because we only
+   * return the user's primary email address.
+   */
+  @JsonProperty("verified_email")
+  private Boolean verifiedEmail;
+}

--- a/app/src/main/java/org/project/domain/member/repository/MemberRepository.java
+++ b/app/src/main/java/org/project/domain/member/repository/MemberRepository.java
@@ -1,0 +1,68 @@
+package org.project.domain.member.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.project.domain.member.domain.Member;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 디비 연결 없이 메모리에 저장하기 위한 레포지토리
+ */
+@Repository
+public class MemberRepository {
+
+  private static final MemberRepository instance = new MemberRepository();
+  private static Long sequence = 0L;
+  // in-memory db
+  private static final Map<Long, Member> store = new HashMap<>();
+
+  public static MemberRepository getInstance() {
+    return instance;
+  }
+
+  public Member save(Member member) {
+    Member memberAlreadyExists = findByEmailAndProvider(member.getEmail(), member.getProvider());
+    if (memberAlreadyExists != null) {
+      return memberAlreadyExists;
+    }
+
+    member.setId(++sequence);
+    store.put(member.getId(), member);
+    return cloneMember(member);
+  }
+
+  public Member findById(Long id) {
+    if (!store.containsKey(id)) {
+      return null;
+    }
+    return cloneMember(store.get(id));
+  }
+
+  // find by email and OAuth provider
+  public Member findByEmailAndProvider(String email, String provider) {
+    Member member = store.values().stream()
+        .filter(m -> m.getEmail().equals(email))
+        .filter(m -> m.getProvider().equals(provider))
+        .findAny()
+        .orElse(null);
+
+    if (member == null) {
+      return null;
+    }
+    return cloneMember(member);
+  }
+
+  private static Member cloneMember(Member member) {
+    return new Member(member.getId(), member.getEmail(), member.getProvider());
+  }
+
+  public void clearStore() {
+    store.clear();
+  }
+
+  public Long getStoreSize() {
+    return (long) store.size();
+  }
+
+
+}

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -1,16 +1,144 @@
 package org.project.domain.member.service;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.project.domain.member.domain.Member;
 import org.project.domain.member.dto.AuthTokens;
+import org.project.domain.member.dto.OAuthAccessTokenResponse;
+import org.project.domain.member.dto.UserInfoResponse;
+import org.project.domain.member.repository.MemberRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class OAuthService {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+  private final WebClient webClient = WebClient.create();
+
+  private final MemberRepository memberRepository;
+
+  private final String googleClientId;
+  private final String googleClientSecret;
+  private final String googleRedirectUri;
+  private final String accessSecret;
+  private final String refreshSecret;
+  private final Long accessExpiration;
+  private final Long refreshExpiration;
+
+  private final Map<String, Boolean> refreshTokens = new ConcurrentHashMap<>();
+
+  OAuthService(
+      MemberRepository memberRepository,
+      @Value("${oauth2.google.client-id}")
+      String googleClientId,
+      @Value("${oauth2.google.client-secret}")
+      String googleClientSecret,
+      @Value("${oauth2.google.redirect-uri}")
+      String googleRedirectUri,
+      @Value("${jwt.access-secret}")
+      String accessSecret,
+      @Value("${jwt.refresh-secret}")
+      String refreshSecret,
+      @Value("${jwt.access-expiration}")
+      Long accessExpiration,
+      @Value("${jwt.refresh-expiration}")
+      Long refreshExpiration
+  ) {
+    this.memberRepository = memberRepository;
+    this.googleClientId = googleClientId;
+    this.googleClientSecret = googleClientSecret;
+    this.googleRedirectUri = googleRedirectUri;
+    this.accessSecret = accessSecret;
+    this.refreshSecret = refreshSecret;
+    this.accessExpiration = accessExpiration;
+    this.refreshExpiration = refreshExpiration;
+
+  }
+
 
   public AuthTokens loginWithGoogle(String code) {
-    return new AuthTokens("accessToddken " + code, "refreshToken");
+
+    // Get Google Email
+    String email = getGoogleEmail(code);
+
+    // Check if user exists
+    Member memberInRepository = memberRepository.findByEmailAndProvider(email, "google");
+
+    // Create user if not exists
+    if (memberInRepository == null) {
+      memberInRepository = memberRepository.save(new Member(email, "google"));
+    }
+
+    // Create access token
+    String accessToken = generateToken(
+        Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8)), memberInRepository,
+        new Date(System.currentTimeMillis() + accessExpiration));
+
+    // Create refresh token
+    String refreshToken = generateToken(
+        Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8)), memberInRepository,
+        new Date(System.currentTimeMillis() + refreshExpiration));
+
+    // Cache refresh token in in-memory cache
+    refreshTokens.put(refreshToken, true);
+
+    // Return access token and refresh token
+    return new AuthTokens(accessToken, refreshToken);
+  }
+
+  private String getGoogleEmail(String code) {
+    // Request google access token
+    OAuthAccessTokenResponse response = getGoogleAccessToken(code);
+
+    // Request google user info
+    String googleAccessToken = response.getAccessToken();
+    UserInfoResponse userInfo = getGoogleUserInfo(googleAccessToken);
+
+    // Get google email address from user info
+    String email = userInfo.getEmail();
+    return email;
+  }
+
+  String generateToken(Key key, Member memberInRepository, Date exp) {
+    return Jwts.builder()
+        .setSubject(memberInRepository.getId().toString())
+        .setExpiration(exp)
+        .signWith(key)
+        .compact();
+  }
+
+  private UserInfoResponse getGoogleUserInfo(String accessToken) {
+    return webClient
+        .get()
+        .uri("https://www.googleapis.com/userinfo/v2/me")
+        .header("Authorization", "Bearer " + accessToken)
+        .retrieve()
+        .bodyToMono(UserInfoResponse.class)
+        .block();
+  }
+
+  private OAuthAccessTokenResponse getGoogleAccessToken(String code) {
+    return webClient
+        .post()
+        .uri("https://oauth2.googleapis.com/token")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(BodyInserters.fromFormData("code", code)
+            .with("client_id", googleClientId)
+            .with("client_secret", googleClientSecret)
+            .with("redirect_uri", googleRedirectUri)
+            .with("grant_type", "authorization_code"))
+        .retrieve()
+        .bodyToMono(OAuthAccessTokenResponse.class)
+        .block();
   }
 }

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -1,0 +1,16 @@
+package org.project.domain.member.service;
+
+import org.project.domain.member.dto.AuthTokens;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OAuthService {
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  public AuthTokens loginWithGoogle(String code) {
+    return new AuthTokens("accessToddken " + code, "refreshToken");
+  }
+}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.config.import=optional:secrets.properties

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.config.import=optional:secrets.properties

--- a/app/src/main/resources/static/login.html
+++ b/app/src/main/resources/static/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Social Logins</title>
+</head>
+<body>
+<div class="btns-container">
+  <div id="google-signin-button" class="login-btn">
+    <!--적절한 client_id와 login_uri 설정 필요-->
+    <div id="g_id_onload"
+         data-client_id="457920942728-gs5nrm600o6rpm1e1k4s1ov5kebmtmhf.apps.googleusercontent.com"
+         data-login_uri="http://localhost:8080/api/v1/auth/google"
+         data-auto_prompt="false">
+    </div>
+    <div class="g_id_signin"
+         data-type="standard"
+         data-size="large"
+         data-theme="outline"
+         data-text="sign_in_with"
+         data-shape="rectangular"
+         data-logo_alignment="left">
+    </div>
+  </div>
+</div>
+<!--구글 계정으로 로그인 버튼 스크립트(reference url: https://developers.google.com/identity/gsi/web/guides/overview)-->
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+</body>
+<style>
+  .btns-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+  }
+
+  .btns-container > .login-btn {
+    margin-bottom: 20px;
+  }
+</style>
+</html>

--- a/app/src/main/resources/static/login.html
+++ b/app/src/main/resources/static/login.html
@@ -7,20 +7,11 @@
 <body>
 <div class="btns-container">
   <div id="google-signin-button" class="login-btn">
-    <!--적절한 client_id와 login_uri 설정 필요-->
-    <div id="g_id_onload"
-         data-client_id="457920942728-gs5nrm600o6rpm1e1k4s1ov5kebmtmhf.apps.googleusercontent.com"
-         data-login_uri="http://localhost:8080/api/v1/auth/google"
-         data-auto_prompt="false">
-    </div>
-    <div class="g_id_signin"
-         data-type="standard"
-         data-size="large"
-         data-theme="outline"
-         data-text="sign_in_with"
-         data-shape="rectangular"
-         data-logo_alignment="left">
-    </div>
+    <button type="button">
+      <a href="https://accounts.google.com/o/oauth2/v2/auth?client_id=457920942728-gs5nrm600o6rpm1e1k4s1ov5kebmtmhf.apps.googleusercontent.com&redirect_uri=http://localhost:8080/api/v1/oauth/google&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile">
+        Google Login
+      </a>
+    </button>
   </div>
 </div>
 <!--구글 계정으로 로그인 버튼 스크립트(reference url: https://developers.google.com/identity/gsi/web/guides/overview)-->

--- a/app/src/test/java/org/project/domain/member/controller/OAuthControllerTest.java
+++ b/app/src/test/java/org/project/domain/member/controller/OAuthControllerTest.java
@@ -1,0 +1,38 @@
+package org.project.domain.member.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.project.domain.member.dto.AuthTokens;
+import org.project.domain.member.service.OAuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OAuthController.class)
+public class OAuthControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private OAuthService mockOAuthService;
+
+  @Test
+  void loginWithGoogle() throws Exception {
+    String testAuthCode = "testAuthCode";
+    when(mockOAuthService.loginWithGoogle(testAuthCode)).thenReturn(
+        new AuthTokens("test access", "test refresh"));
+
+    mockMvc.perform(get("/api/v1/oauth/google?code=" + testAuthCode)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.access").exists())
+        .andExpect(jsonPath("$.refresh").exists());
+  }
+
+}

--- a/app/src/test/java/org/project/domain/member/repository/MemberRepositoryTest.java
+++ b/app/src/test/java/org/project/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,145 @@
+package org.project.domain.member.repository;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.project.domain.member.domain.Member;
+
+public class MemberRepositoryTest {
+
+  MemberRepository memberRepository = MemberRepository.getInstance();
+
+  @AfterEach
+  void clearAll() {
+    memberRepository.clearStore();
+  }
+
+  @Test
+  void getInstance_should_return_not_null() {
+    MemberRepository memberRepository = MemberRepository.getInstance();
+    assertThat(memberRepository).isNotNull();
+  }
+
+
+  @Test
+  void save_should_increase_store_size() {
+    // given
+    assertThat(memberRepository.getStoreSize()).isEqualTo(0);
+    Member member = new Member("email", "provider");
+
+    // when
+    memberRepository.save(member);
+
+    // then
+    assertThat(memberRepository.getStoreSize()).isEqualTo(1);
+  }
+
+  @Test
+  void save_should_return_saved_member() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+
+    // when
+    Member savedMember = memberRepository.save(member);
+
+    // then
+    assertThat(savedMember.getEmail()).isEqualTo(email);
+    assertThat(savedMember.getProvider()).isEqualTo(provider);
+  }
+
+  @Test
+  void findById_should_return_member() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+    Member savedMember = memberRepository.save(member);
+
+    // when
+    Member findMember = memberRepository.findById(savedMember.getId());
+
+    // then
+    assertThat(findMember).isEqualTo(savedMember);
+  }
+
+  @Test
+  void findById_should_return_null_with_invalid_id() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+    memberRepository.save(member);
+
+    // when
+    Member findMember = memberRepository.findById(-1L);
+
+    // then
+    assertThat(findMember).isNull();
+  }
+
+  @Test
+  void findByEmailAndProvider_should_return_member_with_exist_email_and_provider() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+    Member savedMember = memberRepository.save(member);
+
+    // when
+    Member findMember = memberRepository.findByEmailAndProvider(email, provider);
+
+    // then
+    assertThat(findMember).isEqualTo(savedMember);
+  }
+
+  @Test
+  void findByEmailAndProvider_should_return_null_with_the_same_email_but_different_provider() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+    memberRepository.save(member);
+
+    // when
+    Member findMember = memberRepository.findByEmailAndProvider(email, "differentProvider");
+
+    // then
+    assertThat(findMember).isNull();
+  }
+
+  @Test
+  void findByEmailAndProvider_should_return_null_with_the_same_provider_but_different_email() {
+    // given
+    String email = "email";
+    String provider = "provider";
+    Member member = new Member(email, provider);
+    memberRepository.save(member);
+
+    // when
+    Member findMember = memberRepository.findByEmailAndProvider("differentEmail", provider);
+
+    // then
+    assertThat(findMember).isNull();
+  }
+
+
+  @Test
+  void findByEmailAndProvider_should_return_null_with_not_exist_member() {
+    // given
+    String email = " ";
+    String provider = " ";
+    assertThat(memberRepository.getStoreSize()).isEqualTo(0);
+
+    // when
+    Member findMember = memberRepository.findByEmailAndProvider(email, provider);
+
+    // then
+    assertThat(findMember).isNull();
+  }
+
+
+}

--- a/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
+++ b/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
@@ -1,0 +1,87 @@
+package org.project.domain.member.service;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import org.project.domain.member.domain.Member;
+import org.project.domain.member.repository.MemberRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class OAuthServiceTest {
+
+  // member repository stub
+  private MemberRepository memberRepository = mock(MemberRepository.class);
+
+  OAuthService oAuthService = new OAuthService(
+      memberRepository,
+      "dummy google client id",
+      "dummy google client secret",
+      "dummy google redirect uri",
+      "access secret",
+      "refresh secret".toString(),
+      1000L,
+      2000L
+  );
+
+  @Test
+  public void generateToken_returns_token_with_proper_exp_claim() {
+    // given
+    Member member = new Member(10L, "test@test.com", "google");
+    Date exp = Date.from(Instant.parse("2021-01-01T00:00:00.00Z"));
+    Key key = Keys.hmacShaKeyFor(
+        "refresh secret must be longer than 256 bitsssssssssssssssss".getBytes(
+            StandardCharsets.UTF_8));
+
+    // when
+    String refreshToken = oAuthService.generateToken(key, member, exp);
+
+    // then
+    Date expInToken;
+    try {
+      expInToken = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(refreshToken)
+          .getBody()
+          .getExpiration();
+    } catch (ExpiredJwtException e) {
+      expInToken = e.getClaims().getExpiration();
+    }
+    assertEquals(exp, expInToken);
+  }
+
+  @Test
+  public void generateToken_returns_token_with_proper_sub_claim() {
+    // given
+    Member member = new Member(10L, "test@test.com", "google");
+    Date exp = Date.from(Instant.parse("2021-01-01T00:00:00.00Z"));
+    Key key = Keys.hmacShaKeyFor(
+        "refresh secret must be longer than 256 bitsssssssssssssssss".getBytes(
+            StandardCharsets.UTF_8));
+
+    // when
+    String refreshToken = oAuthService.generateToken(key, member, exp);
+
+    // then
+    String subInToken;
+    try {
+      subInToken = Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(refreshToken)
+          .getBody()
+          .getSubject();
+    } catch (ExpiredJwtException e) {
+      subInToken = e.getClaims().getSubject();
+    }
+    Long idInSub = Long.parseLong(subInToken);
+    assertEquals(member.getId(), idInSub);
+  }
+}


### PR DESCRIPTION
- `GET /api/v1/oauth/google`
  - 쿼리 스트링으로 `code`를 받는다.
  - 성공시 아래 스키마와 같은 json응답을 반환한다.
    - ```json
       {
           "access": "{access token value}",
           "refresh": "{refresh token value}"
       }
       ```
- 추가되어야 or 나중에 고려해야 할 부분
  - 유저가 요청한 scope에 대해 허가해주지 않아서 요청 쿼리 스트링으로 `code` 대신 `error`를 받은 경우
    - [https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.2.1)
  - 받은 `code`를 통해 `access_code`요청했지만 실패한 경우
    - [https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4)
  - userinfo.email을 요청했지만 실패한 겨우
    - 실패 응답 스키마 명시된 부분 없어서 직접 확인 필요?([https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest](https://www.googleapis.com/discovery/v1/apis/oauth2/v2/rest))
  - Deprecated된 유저 이메일 요청 엔드포인트?
    - 다른 구글 api와 달리 `https://www.googleapis.com/userinfo/v2/me`는 구글 api 디스커버리 목록에서 확인했을 때 deprecated되어 있음
      - 해당 요청 지점에 대한 레퍼런스도 다른 api와 달리 구글 사이트에 나와있지 않음
      - 그런데 google api playground에는 별 다른 설명 없이 올라와 있음
      - 굳이 바꿔야 한다면 people api 사용 고려
  - 테스트 관련 (pr 요청자에 국한된 내용)
    - 어느 영역까지 테스트?
    - 적절한 테스트 형태?
    - 적절한 테스트 책임 분배?
    - 내부에서 `new Date()`와 같은 메소드(or 생성자)에 대한 호출이 있어서 repeatable한 테스트 작성 불가능한 경우 mocking? or 코드 설계의 문제?
    - 테스트 코드가 테스트하고자 하는 메소드/클래스의 내부 구현에 대해 어느 정도까지 알고 있어도 되는지? 이것도 테스트마다 다른지?