### PR TITLE
구글 로그인 테스트 코드 수정 / OAuth서비스 내의 의존성 다른 서비스 클래스로 분리 / 카카오 로그인 api 추가

### DIFF
--- a/app/src/main/java/org/project/AppConfig.java
+++ b/app/src/main/java/org/project/AppConfig.java
@@ -1,0 +1,22 @@
+package org.project;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class AppConfig {
+
+  @Bean
+  public WebClient webClient() {
+    return WebClient.create();
+  }
+
+
+  @Bean(name = "refreshTokens")
+  Map<String, Boolean> refreshTokens() {
+    return new ConcurrentHashMap<>();
+  }
+}

--- a/app/src/main/java/org/project/domain/member/controller/OAuthController.java
+++ b/app/src/main/java/org/project/domain/member/controller/OAuthController.java
@@ -28,4 +28,11 @@ public class OAuthController {
     return ResponseEntity.ok(oAuthService.loginWithGoogle(code));
   }
 
+  @GetMapping("/kakao")
+  public ResponseEntity<AuthTokens> loginWithKakao(@RequestParam(required = false) String code,
+      @RequestParam(required = false) String error) {
+
+    return ResponseEntity.ok(oAuthService.loginWithKakao(code));
+  }
+
 }

--- a/app/src/main/java/org/project/domain/member/domain/Member.java
+++ b/app/src/main/java/org/project/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
 package org.project.domain.member.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Getter
 @Setter
+@Builder
 @AllArgsConstructor
 @RequiredArgsConstructor
 @ToString

--- a/app/src/main/java/org/project/domain/member/dto/GoogleUserInfoResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/GoogleUserInfoResponse.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  */
 @Getter
 @ToString
-public class UserInfoResponse {
+public class GoogleUserInfoResponse {
 
   /**
    * The user's email address.

--- a/app/src/main/java/org/project/domain/member/dto/GoogleUserInfoResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/GoogleUserInfoResponse.java
@@ -1,7 +1,11 @@
 package org.project.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -9,7 +13,11 @@ import lombok.ToString;
  * href="googleapis.com/discovery/v1/apis/oauth2/v2/rest">googleapis.com/discovery/v1/apis/oauth2/v2/rest</a>
  */
 @Getter
+@Setter
 @ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GoogleUserInfoResponse {
 
   /**

--- a/app/src/main/java/org/project/domain/member/dto/KakaoAccount.java
+++ b/app/src/main/java/org/project/domain/member/dto/KakaoAccount.java
@@ -2,7 +2,10 @@ package org.project.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
@@ -11,6 +14,9 @@ import lombok.ToString;
  */
 @Getter
 @ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class KakaoAccount {
 
   /**

--- a/app/src/main/java/org/project/domain/member/dto/KakaoAccount.java
+++ b/app/src/main/java/org/project/domain/member/dto/KakaoAccount.java
@@ -1,0 +1,346 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Kakao API에서 제공하는 사용자 정보 응답 포맷. <a
+ * href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#kakaoaccount">링크</a>
+ */
+@Getter
+@ToString
+public class KakaoAccount {
+
+  /**
+   * 사용자 동의 시 프로필 정보(닉네임/프로필 사진) 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진)
+   * <p>
+   * 문서에 명시된 타입 : Type
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("profile_needs_agreement")
+  private Boolean profileNeedsAgreement;
+
+  /**
+   * 사용자 동의 시 닉네임 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 닉네임
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("profile_nickname_needs_agreement")
+  private Boolean profileNicknameNeedsAgreement;
+
+  /**
+   * 사용자 동의 시 프로필 사진 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 사진
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("profile_image_needs_agreement")
+  private Boolean profileImageNeedsAgreement;
+
+  /**
+   * 프로필 정보
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진), 닉네임, 프로필 사진
+   * <p>
+   * 문서에 명시된 타입 : JSON
+   * <p>
+   * Required: false
+   * <p>
+   * 참고 : <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#profile">링크</a>
+   */
+  @JsonProperty("profile")
+  private KakaoProfile profile;
+
+  /**
+   * 사용자 동의 시 카카오계정 이름 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 이름
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("name_needs_agreement")
+  private Boolean nameNeedsAgreement;
+
+  /**
+   * 카카오계정 이름
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 이름
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("name")
+  private String name;
+
+  /**
+   * 사용자 동의 시 카카오계정 대표 이메일 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(이메일)
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("email_needs_agreement")
+  private Boolean emailNeedsAgreement;
+
+  /**
+   * 이메일 유효 여부
+   * <p>
+   * 의미 :
+   * <p>
+   * - true: 유효한 이메일
+   * <p>
+   * - false: 이메일이 다른 카카오계정에 사용돼 만료
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(이메일)
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("is_email_valid")
+  private Boolean isEmailValid;
+
+  /**
+   * 이메일 인증 여부
+   * <p>
+   * 의미 :
+   * <p>
+   * - true: 인증된 이메일
+   * <p>
+   * - false: 인증되지 않은 이메일
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(이메일)
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("is_email_verified")
+  private Boolean isEmailVerified;
+
+  /**
+   * 카카오계정 대표 이메일
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(이메일)
+   * <p>
+   * 비고: <a
+   * href="https://developers.kakao.com/docs/latest/ko/kakaologin/common#policy-email-caution">이메일
+   * 사용 시 주의사항</a>
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("email")
+  private String email;
+
+  /**
+   * 사용자 동의 시 연령대 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 연령대
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("age_range_needs_agreement")
+  private Boolean ageRangeNeedsAgreement;
+
+  /**
+   * 연령대
+   * <p>
+   * 1~9: 1세 이상 10대 미만
+   * <p>
+   * 10~14: 10세 이상 15세 미만
+   * <p>
+   * 15~19: 15세 이상 20세 미만
+   * <p>
+   * 20~29: 20세 이상 30세 미만
+   * <p>
+   * 30~39: 30세 이상 40세 미만
+   * <p>
+   * 40~49: 40세 이상 50세 미만
+   * <p>
+   * 50~59: 50세 이상 60세 미만
+   * <p>
+   * 60~69: 60세 이상 70세 미만
+   * <p>
+   * 70~79: 70세 이상 80세 미만
+   * <p>
+   * 80~89: 80세 이상 90세 미만
+   * <p>
+   * 90~: 90세 이상
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 연령대
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("age_range")
+  private String ageRange;
+
+  /**
+   * 사용자 동의 시 출생 연도 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 출생 연도
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("birthyear_needs_agreement")
+  private Boolean birthyearNeedsAgreement;
+
+  /**
+   * 출생 연도(YYYY 형식)
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 출생 연도
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("birthyear")
+  private String birthyear;
+
+  /**
+   * 사용자 동의 시 생일 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 생일
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("birthday_needs_agreement")
+  private Boolean birthdayNeedsAgreement;
+
+  /**
+   * 생일(MMDD 형식)
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 생일
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("birthday")
+  private String birthday;
+
+  /**
+   * 사용자 동의 시 성별 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 성별
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("gender_needs_agreement")
+  private Boolean genderNeedsAgreement;
+
+  /**
+   * 성별
+   * <p>
+   * 의미 :
+   * <p>
+   * - female: 여성
+   * <p>
+   * - male: 남성
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 성별
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("gender")
+  private String gender;
+
+  /**
+   * 사용자 동의 시 전화번호 제공 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(전화번호)
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("phone_number_needs_agreement")
+  private Boolean phoneNumberNeedsAgreement;
+
+  /**
+   * 카카오계정의 전화번호
+   * <p>
+   * 국내 번호인 경우 +82 00-0000-0000 형식
+   * <p>
+   * 해외 번호인 경우 자릿수, 붙임표(-) 유무나 위치가 다를 수 있음
+   * <p>
+   * (참고: <a href="https://github.com/google/libphonenumber">libphonenumber</a>)
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 카카오계정(전화번호)
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("phone_number")
+  private String phoneNumber;
+
+  /**
+   * 사용자 동의 시 CI 참고 가능
+   * <p>
+   * <strong>필요한 동의 항목</strong>: CI(연계정보)
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("ci_needs_agreement")
+  private Boolean ciNeedsAgreement;
+
+  /**
+   * 연계정보
+   * <p>
+   * <strong>필요한 동의 항목</strong>: CI(연계정보)
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("ci")
+  private String ci;
+
+  /**
+   * CI 발급 시각, UTC*
+   * <p>
+   * <strong>필요한 동의 항목</strong>: CI(연계정보)
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   * <p>
+   * * <a href="https://ko.wikipedia.org/wiki/세계_협정_시각">UTC</a>: 한국 시간(KST)과 9시간 차이, <a
+   * href="https://tools.ietf.org/html/rfc3339">RFC3339: Date and Time on the Internet</a> 참고
+   */
+  @JsonProperty("ci_authenticated_at")
+  private Date ciAuthenticatedAt;
+}

--- a/app/src/main/java/org/project/domain/member/dto/KakaoProfile.java
+++ b/app/src/main/java/org/project/domain/member/dto/KakaoProfile.java
@@ -1,0 +1,70 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 참고: <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#profile">링크</a>
+ */
+public class KakaoProfile {
+
+  /**
+   * 닉네임
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진) 또는 닉네임
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("nickname")
+  private String nickname;
+
+  /**
+   * 프로필 미리보기 이미지 URL
+   * <p>
+   * 110px * 110px 또는 100px * 100px
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("thumbnail_image_url")
+  private String thumbnailImageUrl;
+
+  /**
+   * 프로필 사진 URL
+   * <p>
+   * 640px * 640px 또는 480px * 480px
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+   * <p>
+   * 문서에 명시된 타입 : String
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("profile_image_url")
+  private String profileImageUrl;
+
+  /**
+   * 프로필 사진 URL이 기본 프로필 사진 URL인지 여부
+   * <p>
+   * 사용자가 등록한 프로필 사진이 없을 경우, 기본 프로필 사진 제공
+   * <p>
+   * 의미 :
+   * <p>
+   * - true: 기본 프로필 사진
+   * <p>
+   * - false: 사용자가 등록한 프로필 사진
+   * <p>
+   * <strong>필요한 동의 항목</strong>: 프로필 정보(닉네임/프로필 사진) 또는 프로필 사진
+   * <p>
+   * 문서에 명시된 타입 : Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("is_default_image")
+  private Boolean isDefaultImage;
+
+}

--- a/app/src/main/java/org/project/domain/member/dto/KakaoUserInfoResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/KakaoUserInfoResponse.java
@@ -3,7 +3,10 @@ package org.project.domain.member.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
@@ -12,6 +15,9 @@ import lombok.ToString;
  */
 @Getter
 @ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class KakaoUserInfoResponse {
 
   /**

--- a/app/src/main/java/org/project/domain/member/dto/KakaoUserInfoResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/KakaoUserInfoResponse.java
@@ -1,0 +1,94 @@
+package org.project.domain.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import java.util.Map;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Schema reference from <a
+ * href="developers.kakao.com/docs/latest/ko/kakaologin/rest-api">developers.kakao.com/docs/latest/ko/kakaologin/rest-api</a>
+ */
+@Getter
+@ToString
+public class KakaoUserInfoResponse {
+
+  /**
+   * 회원번호
+   * <p>
+   * 문서에 명시된 타입: Long
+   * <p>
+   * Required: true
+   */
+  private Long id;
+
+  /**
+   * 자옹 연결 설정을 비활성화한 경우만 존재
+   * <p>
+   * 연결하기 호출의 완료 여부
+   * <p>
+   * 의미 :
+   * <p>
+   * - false: 연결 대기(Preregistered) 상태
+   * <p>
+   * - true: 연결(Registered) 상태
+   * <p>
+   * 문서에 명시된 타입: Boolean
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("has_signed_up")
+  private Boolean hasSignedUp;
+
+  /**
+   * 서비스에 연결 완료된 시각, UTC*
+   * <p>
+   * * UTC : 한국 시간(KST)과 9시간 차이, <a href="https://www.rfc-editor.org/rfc/rfc3339">RFC3339: Date and
+   * Time on the Internet</a> 참고
+   * <p>
+   * 문서에 명시된 타입: Datetime
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("connected_at")
+  private Date connectedAt;
+
+  /**
+   * 카카오싱크 간편가입을 통해 로그인한 시각, UTC*
+   * <p>
+   * * UTC : 한국 시간(KST)과 9시간 차이,  <a href="https://www.rfc-editor.org/rfc/rfc3339">RFC3339: Date and
+   * Time on the Internet</a> 참고
+   * <p>
+   * 문서에 명시된 타입: Datetime
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("synched_at")
+  private Date synchedAt;
+
+  /**
+   * 사용자 프로퍼티(Property)
+   * <p>
+   * <a
+   * href="https://developers.kakao.com/docs/latest/ko/kakaologin/prerequisite#user-properties">사용자
+   * 프로퍼티</a> 참고
+   * <p>
+   * 문서에 명시된 타입: JSON
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("properties")
+  private Map<String, Object> properties;
+
+  /**
+   * 카카오계정 정보
+   * <p>
+   * 문서에 명시된 타입: <a
+   * href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#kakaoaccount">KakaoAccount</a>
+   * <p>
+   * Required: false
+   */
+  @JsonProperty("kakao_account")
+  private KakaoAccount kakaoAccount;
+}

--- a/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
@@ -22,6 +22,9 @@ public class OAuthAccessTokenResponse {
   private String expiresIn;
   @JsonProperty("refresh_token")
   private String refreshToken;
+  @JsonProperty("refresh_token_expires_in")
+  private String refreshTokenExpiresIn;
+  @JsonProperty("scope")
   private String scope;
 
 }

--- a/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
+++ b/app/src/main/java/org/project/domain/member/dto/OAuthAccessTokenResponse.java
@@ -1,8 +1,11 @@
 package org.project.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -11,6 +14,9 @@ import lombok.ToString;
  */
 @ToString
 @Getter
+@Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 public class OAuthAccessTokenResponse {
 

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -12,6 +12,7 @@ import org.project.domain.member.dto.AuthTokens;
 import org.project.domain.member.dto.OAuthAccessTokenResponse;
 import org.project.domain.member.dto.GoogleUserInfoResponse;
 import org.project.domain.member.repository.MemberRepository;
+import org.project.util.JwtService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,8 +24,9 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class OAuthService {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
-  private final WebClient webClient = WebClient.create();
 
+  private final OAuthWebClientService oAuthWebClientService;
+  private final JwtService jwtService;
   private final MemberRepository memberRepository;
 
   private final String googleClientId;
@@ -35,10 +37,13 @@ public class OAuthService {
   private final Long accessExpiration;
   private final Long refreshExpiration;
 
-  private final Map<String, Boolean> refreshTokens = new ConcurrentHashMap<>();
+  private final Map<String, Boolean> refreshTokens;
 
   OAuthService(
+      OAuthWebClientService oAuthWebClientService,
+      JwtService jwtService,
       MemberRepository memberRepository,
+      Map<String, Boolean> refreshTokens,
       @Value("${oauth2.google.client-id}")
       String googleClientId,
       @Value("${oauth2.google.client-secret}")
@@ -54,7 +59,10 @@ public class OAuthService {
       @Value("${jwt.refresh-expiration}")
       Long refreshExpiration
   ) {
+    this.oAuthWebClientService = oAuthWebClientService;
+    this.jwtService = jwtService;
     this.memberRepository = memberRepository;
+    this.refreshTokens = refreshTokens;
     this.googleClientId = googleClientId;
     this.googleClientSecret = googleClientSecret;
     this.googleRedirectUri = googleRedirectUri;
@@ -80,13 +88,15 @@ public class OAuthService {
     }
 
     // Create access token
-    String accessToken = generateToken(
-        Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8)), memberInRepository,
+    String accessToken = jwtService.generateToken(
+        Keys.hmacShaKeyFor(accessSecret.getBytes(StandardCharsets.UTF_8)),
+        memberInRepository.getId().toString(),
         new Date(System.currentTimeMillis() + accessExpiration));
 
     // Create refresh token
-    String refreshToken = generateToken(
-        Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8)), memberInRepository,
+    String refreshToken = jwtService.generateToken(
+        Keys.hmacShaKeyFor(refreshSecret.getBytes(StandardCharsets.UTF_8)),
+        memberInRepository.getId().toString(),
         new Date(System.currentTimeMillis() + refreshExpiration));
 
     // Cache refresh token in in-memory cache
@@ -98,11 +108,12 @@ public class OAuthService {
 
   private String getGoogleEmail(String code) {
     // Request google access token
-    OAuthAccessTokenResponse response = getGoogleAccessToken(code);
+    OAuthAccessTokenResponse response = oAuthWebClientService.getGoogleAccessToken(code,
+        googleClientId, googleClientSecret, googleRedirectUri);
 
     // Request google user info
     String googleAccessToken = response.getAccessToken();
-    GoogleUserInfoResponse userInfo = getGoogleUserInfo(googleAccessToken);
+    GoogleUserInfoResponse userInfo = oAuthWebClientService.getGoogleUserInfo(googleAccessToken);
 
     // Get google email address from user info
     String email = userInfo.getEmail();

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.project.domain.member.domain.Member;
 import org.project.domain.member.dto.AuthTokens;
 import org.project.domain.member.dto.OAuthAccessTokenResponse;
-import org.project.domain.member.dto.UserInfoResponse;
+import org.project.domain.member.dto.GoogleUserInfoResponse;
 import org.project.domain.member.repository.MemberRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +102,7 @@ public class OAuthService {
 
     // Request google user info
     String googleAccessToken = response.getAccessToken();
-    UserInfoResponse userInfo = getGoogleUserInfo(googleAccessToken);
+    GoogleUserInfoResponse userInfo = getGoogleUserInfo(googleAccessToken);
 
     // Get google email address from user info
     String email = userInfo.getEmail();
@@ -117,13 +117,13 @@ public class OAuthService {
         .compact();
   }
 
-  private UserInfoResponse getGoogleUserInfo(String accessToken) {
+  private GoogleUserInfoResponse getGoogleUserInfo(String accessToken) {
     return webClient
         .get()
         .uri("https://www.googleapis.com/userinfo/v2/me")
         .header("Authorization", "Bearer " + accessToken)
         .retrieve()
-        .bodyToMono(UserInfoResponse.class)
+        .bodyToMono(GoogleUserInfoResponse.class)
         .block();
   }
 

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -75,6 +75,9 @@ public class OAuthService {
 
 
   public AuthTokens loginWithGoogle(String code) {
+    if (code == null) {
+      throw new IllegalArgumentException("Authorization code is null");
+    }
 
     // Get Google Email
     String email = getGoogleEmail(code);
@@ -116,8 +119,7 @@ public class OAuthService {
     GoogleUserInfoResponse userInfo = oAuthWebClientService.getGoogleUserInfo(googleAccessToken);
 
     // Get google email address from user info
-    String email = userInfo.getEmail();
-    return email;
+    return userInfo.getEmail();
   }
 
   String generateToken(Key key, Member memberInRepository, Date exp) {
@@ -134,28 +136,5 @@ public class OAuthService {
         .compact();
   }
 
-  private GoogleUserInfoResponse getGoogleUserInfo(String accessToken) {
-    return webClient
-        .get()
-        .uri("https://www.googleapis.com/userinfo/v2/me")
-        .header("Authorization", "Bearer " + accessToken)
-        .retrieve()
-        .bodyToMono(GoogleUserInfoResponse.class)
-        .block();
-  }
 
-  private OAuthAccessTokenResponse getGoogleAccessToken(String code) {
-    return webClient
-        .post()
-        .uri("https://oauth2.googleapis.com/token")
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .body(BodyInserters.fromFormData("code", code)
-            .with("client_id", googleClientId)
-            .with("client_secret", googleClientSecret)
-            .with("redirect_uri", googleRedirectUri)
-            .with("grant_type", "authorization_code"))
-        .retrieve()
-        .bodyToMono(OAuthAccessTokenResponse.class)
-        .block();
-  }
 }

--- a/app/src/main/java/org/project/domain/member/service/OAuthService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthService.java
@@ -110,6 +110,12 @@ public class OAuthService {
   }
 
   String generateToken(Key key, Member memberInRepository, Date exp) {
+    if (memberInRepository == null) {
+      throw new IllegalArgumentException("Member must not be null");
+    }
+    if (exp == null) {
+      throw new IllegalArgumentException("Expiration date must not be null");
+    }
     return Jwts.builder()
         .setSubject(memberInRepository.getId().toString())
         .setExpiration(exp)

--- a/app/src/main/java/org/project/domain/member/service/OAuthWebClientService.java
+++ b/app/src/main/java/org/project/domain/member/service/OAuthWebClientService.java
@@ -1,0 +1,67 @@
+package org.project.domain.member.service;
+
+import org.project.domain.member.dto.GoogleUserInfoResponse;
+import org.project.domain.member.dto.KakaoUserInfoResponse;
+import org.project.domain.member.dto.OAuthAccessTokenResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class OAuthWebClientService {
+
+  WebClient webClient = WebClient.create();
+
+  public GoogleUserInfoResponse getGoogleUserInfo(String accessToken) {
+    return webClient
+        .get()
+        .uri("https://www.googleapis.com/userinfo/v2/me")
+        .header("Authorization", "Bearer " + accessToken)
+        .retrieve()
+        .bodyToMono(GoogleUserInfoResponse.class)
+        .block();
+  }
+
+  KakaoUserInfoResponse getKakaoUserInfo(String accessToken) {
+    return webClient
+        .get()
+        .uri("https://kapi.kakao.com/v2/user/me")
+        .header("Authorization", "Bearer " + accessToken)
+        .retrieve()
+        .bodyToMono(KakaoUserInfoResponse.class)
+        .block();
+  }
+
+  OAuthAccessTokenResponse getGoogleAccessToken(String code, String clientId, String clientSecret,
+      String redirectUri) {
+    return webClient
+        .post()
+        .uri("https://oauth2.googleapis.com/token")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(BodyInserters.fromFormData("code", code)
+            .with("client_id", clientId)
+            .with("client_secret", clientSecret)
+            .with("redirect_uri", redirectUri)
+            .with("grant_type", "authorization_code"))
+        .retrieve()
+        .bodyToMono(OAuthAccessTokenResponse.class)
+        .block();
+  }
+
+  OAuthAccessTokenResponse getKakaoAccessToken(String code, String clientId, String clientSecret,
+      String redirectUri) {
+    return webClient
+        .post()
+        .uri("https://kauth.kakao.com/oauth/token")
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(BodyInserters.fromFormData("code", code)
+            .with("client_id", clientId)
+            .with("client_secret", clientSecret)
+            .with("redirect_uri", redirectUri)
+            .with("grant_type", "authorization_code"))
+        .retrieve()
+        .bodyToMono(OAuthAccessTokenResponse.class)
+        .block();
+  }
+
+}

--- a/app/src/main/resources/static/login.html
+++ b/app/src/main/resources/static/login.html
@@ -13,6 +13,13 @@
       </a>
     </button>
   </div>
+  <div id="kakao-signin-button" class="login-btn">
+    <button type="button">
+      <a href="https://kauth.kakao.com/oauth/authorize?scope=account_email&client_id=6776d295565cca733cea4dc505a0436f&redirect_uri=http://localhost:8080/api/v1/oauth/kakao&response_type=code">
+        Kakao Login
+      </a>
+    </button>
+  </div>
 </div>
 <!--구글 계정으로 로그인 버튼 스크립트(reference url: https://developers.google.com/identity/gsi/web/guides/overview)-->
 <script src="https://accounts.google.com/gsi/client" async defer></script>

--- a/app/src/test/java/org/project/domain/member/controller/OAuthControllerTest.java
+++ b/app/src/test/java/org/project/domain/member/controller/OAuthControllerTest.java
@@ -1,10 +1,12 @@
 package org.project.domain.member.controller;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.project.domain.member.dto.AuthTokens;
 import org.project.domain.member.service.OAuthService;
@@ -23,6 +25,7 @@ public class OAuthControllerTest {
   private OAuthService mockOAuthService;
 
   @Test
+  @DisplayName("구글 로그인 api는 쿼리스트링으로 받은 code를 서비스에게 전달한다.")
   void loginWithGoogle() throws Exception {
     String testAuthCode = "testAuthCode";
     when(mockOAuthService.loginWithGoogle(testAuthCode)).thenReturn(
@@ -33,6 +36,22 @@ public class OAuthControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.access").exists())
         .andExpect(jsonPath("$.refresh").exists());
+    verify(mockOAuthService).loginWithGoogle(testAuthCode);
+  }
+
+  @Test
+  @DisplayName("카카오 로그인 api는 쿼리스트링으로 받은 code를 서비스에게 전달한다.")
+  void loginWithKakao() throws Exception {
+    String testAuthCode = "testAuthCode";
+    when(mockOAuthService.loginWithKakao(testAuthCode)).thenReturn(
+        new AuthTokens("test access", "test refresh"));
+
+    mockMvc.perform(get("/api/v1/oauth/kakao?code=" + testAuthCode)
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.access").exists())
+        .andExpect(jsonPath("$.refresh").exists());
+    verify(mockOAuthService).loginWithKakao(testAuthCode);
   }
 
 }

--- a/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
+++ b/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
@@ -25,39 +25,72 @@ public class OAuthServiceTest {
       "dummy google client secret",
       "dummy google redirect uri",
       "access secret",
-      "refresh secret".toString(),
+      "refresh secret",
       1000L,
       2000L
   );
 
   @Test
-  public void generateToken_returns_token_with_proper_exp_claim() {
+  @DisplayName("모든 파라미터가 올바르게 주어졌을 때 토큰을 생성한다")
+  public void generateToken_whenEveryParamsProper_returnNotNullToken() {
     // given
-    Member member = new Member(10L, "test@test.com", "google");
+    Member member = new Member(10L, "", "");
+    Date exp = Date.from(Instant.parse("2021-01-01T00:00:00.00Z"));
+    Key key = Keys.hmacShaKeyFor(
+        "12345678901234567890123456789012".getBytes(StandardCharsets.UTF_8));
+
+    // when
+    String token = oAuthService.generateToken(key, member, exp);
+
+    // then
+    Assertions.assertThat(token).isInstanceOf(String.class);
+  }
+
+  @Test
+  @DisplayName("member가 null이면 generateToken은 IAE를 던진다")
+  public void generateToken_givenNullMember_throwsNullPointerException() {
+    // given
+    Member member = null;
     Date exp = Date.from(Instant.parse("2021-01-01T00:00:00.00Z"));
     Key key = Keys.hmacShaKeyFor(
         "refresh secret must be longer than 256 bitsssssssssssssssss".getBytes(
             StandardCharsets.UTF_8));
 
-    // when
-    String refreshToken = oAuthService.generateToken(key, member, exp);
-
-    // then
-    Date expInToken;
-    try {
-      expInToken = Jwts.parserBuilder()
-          .setSigningKey(key)
-          .build()
-          .parseClaimsJws(refreshToken)
-          .getBody()
-          .getExpiration();
-    } catch (ExpiredJwtException e) {
-      expInToken = e.getClaims().getExpiration();
-    }
-    assertEquals(exp, expInToken);
+    // when & then
+    Assertions.assertThatThrownBy(() -> oAuthService.generateToken(key, member, exp))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
+  @DisplayName("key가 null이면 generateToken은 IAE를 던진다")
+  public void generateToken_givenNullKey_throwsNullPointerException() {
+    // given
+    Member member = new Member(10L, "", "");
+    Date exp = Date.from(Instant.parse("2021-01-01T00:00:00.00Z"));
+    Key key = null;
+
+    // when & then
+    Assertions.assertThatThrownBy(() -> oAuthService.generateToken(key, member, exp))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("exp가 null이면 generateToken은 IAE를 던진다")
+  public void generateToken_givenNullExp_throwsNullPointerException() {
+    // given
+    Member member = new Member(10L, "", "");
+    Date exp = null;
+    Key key = Keys.hmacShaKeyFor(
+        "refresh secret must be longer than 256 bitsssssssssssssssss".getBytes(
+            StandardCharsets.UTF_8));
+
+    // when & then
+    Assertions.assertThatThrownBy(() -> oAuthService.generateToken(key, member, exp))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("유효한 파라미터가 들어왔을 때 반환된 토큰은 주어진 파라미터와 일치해야 한다")
   public void generateToken_returns_token_with_proper_sub_claim() {
     // given
     Member member = new Member(10L, "test@test.com", "google");

--- a/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
+++ b/app/src/test/java/org/project/domain/member/service/OAuthServiceTest.java
@@ -11,11 +11,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.project.domain.member.domain.Member;
 import org.project.domain.member.dto.AuthTokens;
 import org.project.domain.member.dto.GoogleUserInfoResponse;
+import org.project.domain.member.dto.KakaoAccount;
+import org.project.domain.member.dto.KakaoUserInfoResponse;
 import org.project.domain.member.dto.OAuthAccessTokenResponse;
 import org.project.domain.member.repository.MemberRepository;
 import org.project.util.JwtService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -62,12 +65,27 @@ public class OAuthServiceTest {
   );
 
 
-  void mockAll() {
+  void mockAllForGoogle() {
 
     given(oAuthWebClientService.getGoogleAccessToken(anyString(), anyString(), anyString(),
         anyString())).willReturn(OAuthAccessTokenResponse.builder().accessToken("").build());
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
         GoogleUserInfoResponse.builder().email("").build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(
+        Member.builder().id(10L).email("").provider("").build());
+    given(memberRepository.save(any())).willReturn(
+        Member.builder().id(21L).email("").provider("").build());
+    given(jwtService.generateToken(any(), anyString(), any())).willReturn("token");
+    given(mockRefreshTokens.put(anyString(), anyBoolean())).willReturn(true);
+  }
+
+  void mockAllForKaKao() {
+
+    given(oAuthWebClientService.getKakaoAccessToken(anyString(), anyString(), anyString(),
+        anyString())).willReturn(OAuthAccessTokenResponse.builder().accessToken("").build());
+    given(oAuthWebClientService.getKakaoUserInfo(anyString())).willReturn(
+        KakaoUserInfoResponse.builder().kakaoAccount(
+            KakaoAccount.builder().email("").build()).build());
     given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(
         Member.builder().id(10L).email("").provider("").build());
     given(memberRepository.save(any())).willReturn(
@@ -94,7 +112,7 @@ public class OAuthServiceTest {
   public void loginWithGoogle_callsGetGoogleAccessToken_withGivenVariables() {
     // given
     String code = "code";
-    mockAll();
+    mockAllForGoogle();
     GoogleUserInfoResponse test = oAuthWebClientService.getGoogleUserInfo("access_token");
     System.out.println("tetst = " + test);
 
@@ -118,7 +136,7 @@ public class OAuthServiceTest {
   public void getGoogleEmail_callsGetGoogleUserInfo_withGivenAccessToken() {
     // given
     String accessToken = "access_token";
-    mockAll();
+    mockAllForGoogle();
     given(oAuthWebClientService.getGoogleAccessToken(anyString(), anyString(), anyString(),
         anyString())).willReturn(
         OAuthAccessTokenResponse.builder().accessToken(accessToken).build());
@@ -138,7 +156,7 @@ public class OAuthServiceTest {
   public void getGoogleEmail_callsFindByEmailAndProvider_withGivenEmail() {
     // given
     String email = "email";
-    mockAll();
+    mockAllForGoogle();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
         GoogleUserInfoResponse.builder().email(email).build());
 
@@ -157,7 +175,7 @@ public class OAuthServiceTest {
   public void getGoogleEmail_callsSave_whenUserDoesNotExist() {
     // given
     String email = "email";
-    mockAll();
+    mockAllForGoogle();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
         GoogleUserInfoResponse.builder().email(email).build());
     given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(null);
@@ -177,7 +195,7 @@ public class OAuthServiceTest {
   public void getGoogleEmail_doesNotCallSave_whenUserExists() {
     // given
     String email = "email";
-    mockAll();
+    mockAllForGoogle();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
         GoogleUserInfoResponse.builder().email(email).build());
     given(memberRepository.findByEmailAndProvider(email, "google")).willReturn(
@@ -197,7 +215,7 @@ public class OAuthServiceTest {
   @DisplayName("loginWithGoogle은 적절한 파라미터로 generateToken을 호출한다.")
   public void getGoogleEmail_callsGenerateToken_withProperParameters() {
     // given
-    mockAll();
+    mockAllForGoogle();
     String email = "email";
     Member member = Member.builder().id(10L).email(email).provider("google").build();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
@@ -223,7 +241,7 @@ public class OAuthServiceTest {
   @DisplayName("loginWithGoogle은 generateToken에서 반환한 refreshToken을 refreshTokens에 저장한다.")
   public void getGoogleEmail_savesRefreshToken() {
     // given
-    mockAll();
+    mockAllForGoogle();
     String email = "email";
     Member member = Member.builder().id(10L).email(email).provider("google").build();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
@@ -250,7 +268,7 @@ public class OAuthServiceTest {
   @DisplayName("loginWithGoogle은 유저의 정보로 생성된 AuthTokens를 반환한다.")
   public void getGoogleEmail_returnsAuthTokens() {
     // given
-    mockAll();
+    mockAllForGoogle();
     String email = "email";
     Member member = Member.builder().id(10L).email(email).provider("google").build();
     given(oAuthWebClientService.getGoogleUserInfo(anyString())).willReturn(
@@ -274,4 +292,231 @@ public class OAuthServiceTest {
       assertThat(authTokens.getRefresh()).isEqualTo(refreshToken);
     }
   }
+
+  @Test
+  @DisplayName("loginWithKakao는 null code를 받으면 IllegalArgumentException을 던진다.")
+  public void loginWithKakao_throwsIllegalArgumentException_whenNullCode() {
+    // given
+    String code = null;
+
+    // when & then
+    assertThatThrownBy(() -> oAuthService.loginWithKakao(code))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 받은 code로 oAuthWebClientService의 getKakaoAccessToken을 호출한다.")
+  public void loginWithKakao_callsGetKakaoAccessToken() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any())).thenReturn(mock(SecretKey.class));
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(oAuthWebClientService).getKakaoAccessToken(code, kakaoClientId, kakaoClientSecret,
+        kakaoRedirectUri);
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 oAuthWebClientService의 getKakaoAccessToken에서 반환한 OAuthAccessTokenResponse로 getKakaoUserInfo를 호출한다.")
+  public void loginWithKakao_callsGetKakaoUserInfo() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String kakaoAccessToken = "kakao_access_token";
+
+    given(oAuthWebClientService.getKakaoAccessToken(anyString(), anyString(), anyString(),
+        anyString()))
+        .willReturn(OAuthAccessTokenResponse.builder()
+            .accessToken(kakaoAccessToken)
+            .build());
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any())).thenReturn(mock(SecretKey.class));
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(oAuthWebClientService).getKakaoUserInfo(kakaoAccessToken);
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 받은 email을 이용해 memberRepository의 findByEmailAndProvider를 호출한다.")
+  public void loginWithKakao_callsFindByEmailAndProvider() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any())).thenReturn(mock(SecretKey.class));
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(memberRepository).findByEmailAndProvider(email, "kakao");
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 memberRepository의 findByEmailAndProvider에서 반환한 Member가 null이면 memberRepository의 save를 호출한다.")
+  public void loginWithKakao_callsSave() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(null);
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any())).thenReturn(mock(SecretKey.class));
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(memberRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 memberRepository의 findByEmailAndProvider에서 반환한 Member가 null이 아니면 memberRepository의 save를 호출하지 않는다.")
+  public void loginWithKakao_doesNotCallSave() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString()))
+        .willReturn(Member.builder().id(30L).email(email).provider("kakao").build());
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any())).thenReturn(mock(SecretKey.class));
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(memberRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 적절한 파라미터로 generateToken을 호출한다.")
+  public void loginWithKakao_callsGenerateToken() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+    Member member = Member.builder().id(30L).email(email).provider("kakao").build();
+
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(member);
+    SecretKey accessSecretKey = mock(SecretKey.class);
+    SecretKey refreshSecretKey = mock(SecretKey.class);
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any()))
+          .thenReturn(accessSecretKey)
+          .thenReturn(refreshSecretKey);
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(jwtService).generateToken(eq(accessSecretKey), eq(member.getId().toString()), any());
+    verify(jwtService).generateToken(eq(refreshSecretKey), eq(member.getId().toString()), any());
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 generateToken에서 반환한 refreshToken을 refreshTokens에 저장한다.")
+  public void loginWithKakao_savesRefreshToken() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+    Member member = Member.builder().id(30L).email(email).provider("kakao").build();
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(member);
+    SecretKey accessSecretKey = mock(SecretKey.class);
+    SecretKey refreshSecretKey = mock(SecretKey.class);
+    String refreshToken = "refresh_token";
+    given(jwtService.generateToken(any(), any(), any())).willReturn(refreshToken);
+
+    // when
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any()))
+          .thenReturn(accessSecretKey)
+          .thenReturn(refreshSecretKey);
+      oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    verify(mockRefreshTokens).put(refreshToken, true);
+  }
+
+  @Test
+  @DisplayName("loginWithKakao는 유저의 정보로 생성된 AuthTokens를 반환한다.")
+  public void loginWithKakao_returnsAuthTokens() {
+    // given
+    mockAllForKaKao();
+    String code = "code";
+    String email = "email";
+    Member member = Member.builder().id(30L).email(email).provider("kakao").build();
+    given(oAuthWebClientService.getKakaoUserInfo(anyString()))
+        .willReturn(KakaoUserInfoResponse.builder()
+            .kakaoAccount(KakaoAccount.builder()
+                .email(email).build())
+            .build());
+    given(memberRepository.findByEmailAndProvider(anyString(), anyString())).willReturn(member);
+    SecretKey accessSecretKey = mock(SecretKey.class);
+    SecretKey refreshSecretKey = mock(SecretKey.class);
+    String accessToken = "access_token";
+    String refreshToken = "refresh_token";
+    given(jwtService.generateToken(any(), any(), any()))
+        .willReturn(accessToken)
+        .willReturn(refreshToken);
+
+    // when
+    AuthTokens authTokens;
+    try (MockedStatic<Keys> utilities = mockStatic(Keys.class)) {
+      utilities.when(() -> Keys.hmacShaKeyFor(any()))
+          .thenReturn(accessSecretKey)
+          .thenReturn(refreshSecretKey);
+      authTokens = oAuthService.loginWithKakao(code);
+    }
+
+    // then
+    assertThat(authTokens.getAccess()).isEqualTo(accessToken);
+    assertThat(authTokens.getRefresh()).isEqualTo(refreshToken);
+  }
+
 }

--- a/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
- 로그인 서비스에서 web client에 직접 의존하고 있는 부분을 OAuthWebClientService로 분리했습니다.
- 토큰 저장 객체와 멤버 리포지토리도 아직 디비를 연결하지는 않았지만 빈으로 등록해서 해당 기능에 대한 검증 책임은 OAuthService에서 다루지 않으려고 했습니다.
- resource의 추가된 파일은 SecretKey객체를 생성하는 Keys클래스의 스태틱 메소드를 mocking하기 위해 추가했습니다.
  - [https://www.baeldung.com/mockito-mock-static-methods](https://www.baeldung.com/mockito-mock-static-methods)
- OAuth서비스의 테스트는 메소드의 로직 단계별로 의도한 호출이 이루어졌는지 검증하고자 했습니다.
- 기존의 구글 로그인 서비스의 테스트도 위의 변경 사항에 맞춰서 수정했습니다.