### PR TITLE
커스텀 에러 및 핸들러 추가 (GlobalExceptionHandler / OAuthCodeRequestFailedException / GenericErrorResponse)

### DIFF
--- a/app/src/main/java/org/project/common/dto/GenericErrorResponse.java
+++ b/app/src/main/java/org/project/common/dto/GenericErrorResponse.java
@@ -1,0 +1,14 @@
+package org.project.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GenericErrorResponse {
+
+  private final String timestamp;
+  private final int status;
+  private final String error;
+  private final String message;
+}

--- a/app/src/main/java/org/project/domain/user/controller/AuthController.java
+++ b/app/src/main/java/org/project/domain/user/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.project.domain.user.dto.OAuthLoginQueryParameter;
 import org.project.domain.user.dto.OAuthLoginResponse;
 import org.project.domain.user.dto.AuthLogoutRequest;
 import org.project.domain.user.service.AuthService;
+import org.project.exception.OAuthCodeRequestFailException;
 import org.project.domain.user.dto.TokenRefreshRequest;
 import org.project.domain.user.dto.TokenRefreshResponse;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +29,11 @@ public class AuthController {
   @GetMapping("/google")
   public ResponseEntity<OAuthLoginResponse> loginWithGoogle(OAuthLoginQueryParameter request) {
     if (request.getError() != null) {
-      // TODO: 어떤 Error 던질 것인지
-      throw new UnsupportedOperationException(
-          "oAuthLoginController.loginWithGoogle() error handling not implemented.");
+      throw new OAuthCodeRequestFailException(
+          "Authorization code request failed with error: " + request.getError());
+    }
+    if (request.getCode() == null) {
+      throw new OAuthCodeRequestFailException("Code or error parameter is required.");
     }
     AuthTokens authTokens = authService.loginWithGoogle(request.getCode());
     return ResponseEntity.ok(new OAuthLoginResponse(authTokens));

--- a/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
+++ b/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package org.project.exception;
+
+import org.project.common.dto.GenericErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(OAuthCodeRequestFailException.class)
+  public ResponseEntity<GenericErrorResponse> handleOAuthCodeRequestFailException(
+      OAuthCodeRequestFailException e) {
+    GenericErrorResponse errorResponse = new GenericErrorResponse(
+        String.valueOf(System.currentTimeMillis()), HttpStatus.BAD_REQUEST.value(),
+        HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+  }
+
+}

--- a/app/src/main/java/org/project/exception/OAuthCodeRequestFailException.java
+++ b/app/src/main/java/org/project/exception/OAuthCodeRequestFailException.java
@@ -1,0 +1,21 @@
+package org.project.exception;
+
+public class OAuthCodeRequestFailException extends RuntimeException {
+
+  public OAuthCodeRequestFailException(String message) {
+    super(message);
+  }
+
+  public OAuthCodeRequestFailException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public OAuthCodeRequestFailException(Throwable cause) {
+    super(cause);
+  }
+
+  public OAuthCodeRequestFailException() {
+    super();
+  }
+
+}


### PR DESCRIPTION
- oauth2 리다이렉션 쿼리 스트링으로 `error`가 들어오는 경우 `OAuthCodeRequestFailedException`을 던지도록 수정
- `RestControllerAdvice` 어노테이션을 추가한 `GlobalExceptionHandler`를 작성한 후 `OAuthCodeRequestFailedException` 핸들러를 작성
- 에러 응답 바디를 위한 `GenericErrorResponse`클래스 작성