### PR TITLE
feat: AccessTokenRequiredAspect 작성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     // database

--- a/app/src/main/java/org/project/annotation/AccessTokenRequired.java
+++ b/app/src/main/java/org/project/annotation/AccessTokenRequired.java
@@ -1,0 +1,15 @@
+package org.project.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME) // 스프링 aop가 런타임에 어노테이션 정보를 확인 할 수 있도록 설정
+@Target(ElementType.METHOD) // 어노테이션을 메소드에만 붙일 수 있도록 설정
+public @interface AccessTokenRequired {
+
+
+}

--- a/app/src/main/java/org/project/aspect/AccessTokenRequiredAspect.java
+++ b/app/src/main/java/org/project/aspect/AccessTokenRequiredAspect.java
@@ -1,0 +1,59 @@
+package org.project.aspect;
+
+import java.util.stream.IntStream;
+import javax.servlet.http.HttpServletRequest;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.project.exception.InvalidAuthorizationHeaderException;
+import org.project.exception.TokenRequiredException;
+import org.project.service.LoginCommonService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class AccessTokenRequiredAspect {
+
+  private final LoginCommonService loginCommonService;
+
+  public AccessTokenRequiredAspect(LoginCommonService loginCommonService) {
+    this.loginCommonService = loginCommonService;
+  }
+
+  /**
+   * 대상 메소드에 `@AccessTokenRequired` 어노테이션을 붙이고, String email 파라미터를 메소드에 추가해주면 적용된다.
+   *
+   * @param joinPoint
+   * @param email
+   * @return
+   * @throws Throwable
+   */
+  @Around("@annotation(org.project.annotation.AccessTokenRequired) && args(.., email)")
+  public Object accessToken(ProceedingJoinPoint joinPoint, String email) throws Throwable {
+    System.out.println("joinPoint = " + joinPoint);
+    ServletRequestAttributes requestAttributes = (ServletRequestAttributes) RequestContextHolder.currentRequestAttributes();
+    HttpServletRequest request = requestAttributes.getRequest();
+    String authHeader = request.getHeader("Authorization");
+    if (authHeader == null) {
+      throw new TokenRequiredException();
+    } else if (!authHeader.startsWith("Bearer ")) {
+      throw new InvalidAuthorizationHeaderException();
+    } else {
+      String accessToken = authHeader.substring(7);
+      loginCommonService.validateAccessToken(accessToken);
+      email = loginCommonService.getSubFromAccessToken(accessToken);
+
+      // Replace email argument with email from access token.
+      String[] parameterNames = ((MethodSignature) joinPoint.getSignature()).getParameterNames();
+      Object[] args = joinPoint.getArgs();
+      String finalEmail = email;
+      IntStream.range(0, parameterNames.length)
+          .filter(i -> parameterNames[i].equals("email"))
+          .forEach(i -> args[i] = finalEmail);
+      return joinPoint.proceed(args);
+    }
+  }
+}

--- a/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
+++ b/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
@@ -29,4 +29,33 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
   }
 
+  @ExceptionHandler(InvalidAccessTokenException.class)
+  public ResponseEntity<GenericErrorResponse> handleExpiredAccessTokenException(
+      InvalidAccessTokenException e) {
+    GenericErrorResponse response = new GenericErrorResponse(
+        String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
+        HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
+    );
+    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(TokenRequiredException.class)
+  public ResponseEntity<GenericErrorResponse> handleTokenRequiredException(
+      TokenRequiredException e) {
+    GenericErrorResponse response = new GenericErrorResponse(
+        String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
+        HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
+    );
+    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(InvalidAuthorizationHeaderException.class)
+  public ResponseEntity<GenericErrorResponse> handleInvalidAuthorizationHeaderException(
+      InvalidAuthorizationHeaderException e) {
+    GenericErrorResponse response = new GenericErrorResponse(
+        String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
+        HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
+    );
+    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
+  }
 }

--- a/app/src/main/java/org/project/exception/InvalidAccessTokenException.java
+++ b/app/src/main/java/org/project/exception/InvalidAccessTokenException.java
@@ -1,0 +1,9 @@
+package org.project.exception;
+
+public class InvalidAccessTokenException extends RuntimeException {
+
+  public InvalidAccessTokenException() {
+    super("Invalid access token");
+  }
+
+}

--- a/app/src/main/java/org/project/exception/InvalidAuthorizationHeaderException.java
+++ b/app/src/main/java/org/project/exception/InvalidAuthorizationHeaderException.java
@@ -1,0 +1,9 @@
+package org.project.exception;
+
+public class InvalidAuthorizationHeaderException extends RuntimeException {
+
+  public InvalidAuthorizationHeaderException() {
+    super("Invalid authorization header");
+  }
+
+}

--- a/app/src/main/java/org/project/exception/TokenRequiredException.java
+++ b/app/src/main/java/org/project/exception/TokenRequiredException.java
@@ -1,0 +1,9 @@
+package org.project.exception;
+
+public class TokenRequiredException extends RuntimeException {
+
+  public TokenRequiredException() {
+    super("Token required");
+  }
+
+}

--- a/app/src/main/java/org/project/service/JJwtService.java
+++ b/app/src/main/java/org/project/service/JJwtService.java
@@ -88,4 +88,19 @@ public class JJwtService implements JwtService {
       throw new IllegalArgumentException("Invalid token");
     }
   }
+
+  @Override
+  public boolean isTokenValid(Key key, String token) {
+    try {
+      Jwts.parserBuilder()
+          .setSigningKey(key)
+          .build()
+          .parseClaimsJws(token);
+      return true;
+    } catch (ExpiredJwtException e) {
+      return true;
+    } catch (JwtException e) {
+      return false;
+    }
+  }
 }

--- a/app/src/main/java/org/project/service/JwtService.java
+++ b/app/src/main/java/org/project/service/JwtService.java
@@ -67,4 +67,9 @@ public interface JwtService {
    * @throws IllegalArgumentException
    */
   boolean isTokenSignValid(Key key, String token) throws IllegalArgumentException;
+
+  /**
+   * 주어진 token이 유효한지 확인한다.
+   */
+  boolean isTokenValid(Key key, String token);
 }

--- a/app/src/main/java/org/project/service/LoginCommonService.java
+++ b/app/src/main/java/org/project/service/LoginCommonService.java
@@ -8,6 +8,7 @@ import java.time.ZoneId;
 import java.util.Date;
 import org.project.domain.Member;
 import org.project.dto.AuthTokens;
+import org.project.exception.InvalidAccessTokenException;
 import org.project.repository.RefreshTokenRepository;
 import org.project.exception.InvalidRefreshTokenException;
 import org.springframework.beans.factory.annotation.Value;
@@ -87,5 +88,15 @@ public class LoginCommonService {
         .plusSeconds(accessExpireTimeInSeconds)
         .atZone(ZoneId.systemDefault()).toInstant());
     return jwtService.generateToken(accessKey, email, accessExp);
+  }
+
+  public void validateAccessToken(String accessToken) {
+    if (!jwtService.isTokenValid(accessKey, accessToken)) {
+      throw new InvalidAccessTokenException();
+    }
+  }
+
+  public String getSubFromAccessToken(String accessToken) {
+    return jwtService.getTokenSub(accessKey, accessToken);
   }
 }


### PR DESCRIPTION
- 메소드에 `@AccessTokenRequired` 어노테이션을 추가 & 파라미터에 email 추가한 메소드에 적용됨
- 해당 메소드를 호출하는 http 요청에는 다음 헤더를 추가해야 한다.
```
Authorization: Bearer {access token}
```
지정된 토큰에 따라 인가 여부를 결정한 후 메소드를 실행시키거나 예외를 던지게 된다.