### PR TITLE
refactor: api 응답 컨트롤러 메소드에서 `ResponseEntity` 반환하지 않도록 수정

### DIFF
--- a/app/src/main/java/org/project/controller/AuthController.java
+++ b/app/src/main/java/org/project/controller/AuthController.java
@@ -9,11 +9,12 @@ import org.project.service.AuthService;
 import org.project.exception.OAuthCodeRequestFailException;
 import org.project.dto.TokenRefreshRequest;
 import org.project.dto.TokenRefreshResponse;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,7 +28,8 @@ public class AuthController {
   }
 
   @GetMapping("/google")
-  public ResponseEntity<OAuthLoginResponse> loginWithGoogle(OAuthLoginQueryParameter request) {
+  @ResponseStatus(HttpStatus.OK)
+  public OAuthLoginResponse loginWithGoogle(OAuthLoginQueryParameter request) {
     if (request.getError() != null) {
       throw new OAuthCodeRequestFailException(
           "Authorization code request failed with error: " + request.getError());
@@ -36,19 +38,20 @@ public class AuthController {
       throw new OAuthCodeRequestFailException("Code or error parameter is required.");
     }
     AuthTokens authTokens = authService.loginWithGoogle(request.getCode());
-    return ResponseEntity.ok(new OAuthLoginResponse(authTokens));
+    return new OAuthLoginResponse(authTokens);
   }
 
   @PostMapping("/refresh")
-  public ResponseEntity<TokenRefreshResponse> refreshAccessToken(
+  @ResponseStatus(HttpStatus.OK)
+  public TokenRefreshResponse refreshAccessToken(
       @Valid @RequestBody TokenRefreshRequest request) {
     String accessToken = authService.refreshAccessToken(request.getRefresh());
-    return ResponseEntity.ok(new TokenRefreshResponse(accessToken));
+    return new TokenRefreshResponse(accessToken);
   }
 
   @PostMapping("/logout")
-  public ResponseEntity<Void> logout(@Valid @RequestBody AuthLogoutRequest request) {
+  @ResponseStatus(HttpStatus.OK)
+  public void logout(@Valid @RequestBody AuthLogoutRequest request) {
     authService.logout(request.getRefresh());
-    return ResponseEntity.ok().build();
   }
 }

--- a/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
+++ b/app/src/main/java/org/project/exception/GlobalExceptionHandler.java
@@ -2,8 +2,8 @@ package org.project.exception;
 
 import org.project.dto.GenericErrorResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
@@ -11,51 +11,51 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(OAuthCodeRequestFailException.class)
-  public ResponseEntity<GenericErrorResponse> handleOAuthCodeRequestFailException(
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public GenericErrorResponse handleOAuthCodeRequestFailException(
       OAuthCodeRequestFailException e) {
-    GenericErrorResponse errorResponse = new GenericErrorResponse(
+    return new GenericErrorResponse(
         String.valueOf(System.currentTimeMillis()), HttpStatus.BAD_REQUEST.value(),
         HttpStatus.BAD_REQUEST.getReasonPhrase(), e.getMessage());
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
   }
 
   @ExceptionHandler(InvalidRefreshTokenException.class)
-  public ResponseEntity<GenericErrorResponse> handleInvalidRefreshTokenException(
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public GenericErrorResponse handleInvalidRefreshTokenException(
       InvalidRefreshTokenException e) {
-    GenericErrorResponse response = new GenericErrorResponse(
+    return new GenericErrorResponse(
         String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
         HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
     );
-    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
   }
 
   @ExceptionHandler(InvalidAccessTokenException.class)
-  public ResponseEntity<GenericErrorResponse> handleExpiredAccessTokenException(
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public GenericErrorResponse handleExpiredAccessTokenException(
       InvalidAccessTokenException e) {
-    GenericErrorResponse response = new GenericErrorResponse(
+    return new GenericErrorResponse(
         String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
         HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
     );
-    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
   }
 
   @ExceptionHandler(TokenRequiredException.class)
-  public ResponseEntity<GenericErrorResponse> handleTokenRequiredException(
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public GenericErrorResponse handleTokenRequiredException(
       TokenRequiredException e) {
-    GenericErrorResponse response = new GenericErrorResponse(
+    return new GenericErrorResponse(
         String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
         HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
     );
-    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
   }
 
   @ExceptionHandler(InvalidAuthorizationHeaderException.class)
-  public ResponseEntity<GenericErrorResponse> handleInvalidAuthorizationHeaderException(
+  @ResponseStatus(HttpStatus.UNAUTHORIZED)
+  public GenericErrorResponse handleInvalidAuthorizationHeaderException(
       InvalidAuthorizationHeaderException e) {
-    GenericErrorResponse response = new GenericErrorResponse(
+    return new GenericErrorResponse(
         String.valueOf(System.currentTimeMillis()), HttpStatus.UNAUTHORIZED.value(),
         HttpStatus.UNAUTHORIZED.getReasonPhrase(), e.getMessage()
     );
-    return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
   }
 }


### PR DESCRIPTION

- 기존 코드에서 `@RestControllerAdvice`, `@RestController`를 사용하던 부분은 두 어노테이션 안에 이미 `@ResponseBody`를 포함하고 있기에 `@ResponseStatus`를 통해 응답 상태 코드만 지정해주면 되는 상황
- 전부 직접 응답 바디 dto 클래스를 반환하도록 수정